### PR TITLE
Revert DEFAULT_AGC_GAINLEVEL to 8000

### DIFF
--- a/Library/TeamTalk.NET/TeamTalk.cs
+++ b/Library/TeamTalk.NET/TeamTalk.cs
@@ -1597,7 +1597,7 @@ namespace BearWare
     public struct AudioConfigConstants
     {
         public const bool DEFAULT_AGC_ENABLE = false;
-        public const int DEFAULT_AGC_GAINLEVEL = 9600;
+        public const int DEFAULT_AGC_GAINLEVEL = 8000;
         public const int DEFAULT_AGC_INC_MAXDB = 12;
     }
 

--- a/Library/TeamTalkJNI/src/dk/bearware/AudioConfigConstants.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/AudioConfigConstants.java
@@ -26,5 +26,5 @@ package dk.bearware;
 public interface AudioConfigConstants {
 
     public static final boolean DEFAULT_AGC_ENABLE = false;
-    public static final int DEFAULT_AGC_GAINLEVEL = 9600;
+    public static final int DEFAULT_AGC_GAINLEVEL = 8000;
 }


### PR DESCRIPTION
Android client should use TeamTalkConstants.DEFAULT_CHANNEL_AUDIOCONFIG_LEVEL.

Keep default AudioConfig values unchanged.