### PR TITLE
Revert to DEFAULT_AGC_ENABLE to true

### DIFF
--- a/Library/TeamTalk.NET/TeamTalk.cs
+++ b/Library/TeamTalk.NET/TeamTalk.cs
@@ -1596,7 +1596,7 @@ namespace BearWare
 
     public struct AudioConfigConstants
     {
-        public const bool DEFAULT_AGC_ENABLE = false;
+        public const bool DEFAULT_AGC_ENABLE = true;
         public const int DEFAULT_AGC_GAINLEVEL = 8000;
         public const int DEFAULT_AGC_INC_MAXDB = 12;
     }

--- a/Library/TeamTalkJNI/src/dk/bearware/AudioConfigConstants.java
+++ b/Library/TeamTalkJNI/src/dk/bearware/AudioConfigConstants.java
@@ -25,6 +25,6 @@ package dk.bearware;
 
 public interface AudioConfigConstants {
 
-    public static final boolean DEFAULT_AGC_ENABLE = false;
+    public static final boolean DEFAULT_AGC_ENABLE = true;
     public static final int DEFAULT_AGC_GAINLEVEL = 8000;
 }


### PR DESCRIPTION
This will make a squash commit treat the values as unchanged and thereby keeps existing compatibility